### PR TITLE
Aos 2349 - schema validation for version 1 and 2 

### DIFF
--- a/pkg/docker/registry.go
+++ b/pkg/docker/registry.go
@@ -4,11 +4,11 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"github.com/docker/docker/image"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"github.com/docker/docker/image"
-	"github.com/pkg/errors"
 )
 
 type ImageInfoProvider interface {

--- a/pkg/docker/registry_test.go
+++ b/pkg/docker/registry_test.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"testing"
 	"strings"
+	"testing"
 )
 
 const repository = "aurora/flange"
@@ -179,7 +179,6 @@ func startMockRegistryServer(filename string) (*httptest.Server, error) {
 	return ts, nil
 }
 
-
 func startMockRegistryManifestServer(fileManifest string, fileImageMeta string) (*httptest.Server, error) {
 	bufManifest, err := ioutil.ReadFile(fileManifest)
 
@@ -205,7 +204,7 @@ func startMockRegistryManifestServer(fileManifest string, fileImageMeta string) 
 			buf = bufManifest
 		} else if strings.Contains(r.Header.Get("Accept"), httpHeaderContainerImageV1) {
 			buf = bufImageMeta
-		} else  {
+		} else {
 			buf = bufManifestError
 		}
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(buf)))

--- a/pkg/docker/registry_test.go
+++ b/pkg/docker/registry_test.go
@@ -7,14 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"strings"
 )
 
-const repository = "aurora/oracle8"
-const tag = "1"
+const repository = "aurora/flange"
+const tag = "8"
 
-const expected_version = "1.7.0"
-
-func TestGetManifestEnv(t *testing.T) {
+func TestGetManifestEnvSchemaV1(t *testing.T) {
+	expectedVersion := "1.7.0"
 
 	server, err := startMockRegistryServer("testdata/manifest.json")
 
@@ -24,13 +24,14 @@ func TestGetManifestEnv(t *testing.T) {
 
 	target := NewRegistryClient(server.URL)
 
-	manifestEnvMap, err := target.GetManifestEnvMap("aurora/oracle8", "1")
+	manifestEnvMap, err := target.GetManifestEnvMap(repository, tag)
 	assert.NoError(t, err)
 	actualVersion := manifestEnvMap["BASE_IMAGE_VERSION"]
-	assert.Equal(t, actualVersion, expected_version)
+	assert.Equal(t, expectedVersion, actualVersion)
 }
 
-func TestGetManifestEnvMap(t *testing.T) {
+func TestGetCompleteBaseImageVersionSchemaV1(t *testing.T) {
+	expectedVersion := "1.7.0"
 
 	server, err := startMockRegistryServer("testdata/manifest.json")
 
@@ -40,13 +41,80 @@ func TestGetManifestEnvMap(t *testing.T) {
 
 	target := NewRegistryClient(server.URL)
 
-	envMap, err := target.GetManifestEnvMap("aurora/oracle8", "1")
+	actualVersion, err := target.GetCompleteBaseImageVersion(repository, tag)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedVersion, actualVersion)
+}
+
+func TestGetManifestEnvMapSchemaV1(t *testing.T) {
+	expectedLength := 14
+
+	server, err := startMockRegistryServer("testdata/manifest.json")
+
+	defer server.Close()
 
 	assert.NoError(t, err)
 
-	expected_len := 14
-	actual_len := len(envMap)
-	assert.Equal(t, expected_len, actual_len)
+	target := NewRegistryClient(server.URL)
+
+	envMap, err := target.GetManifestEnvMap(repository, tag)
+
+	assert.NoError(t, err)
+
+	actualLength := len(envMap)
+	assert.Equal(t, expectedLength, actualLength)
+}
+
+func TestGetManifestEnvSchemaV2(t *testing.T) {
+	expectedVersion := "8.152.18"
+
+	server, err := startMockRegistryManifestServer("testdata/aurora_flange_manifest_v2.json", "testdata/aurora_flange_container_image_v1.json")
+
+	defer server.Close()
+
+	assert.NoError(t, err)
+
+	target := NewRegistryClient(server.URL)
+
+	manifestEnvMap, err := target.GetManifestEnvMap(repository, tag)
+	assert.NoError(t, err)
+	actualVersion := manifestEnvMap["BASE_IMAGE_VERSION"]
+	assert.Equal(t, expectedVersion, actualVersion)
+}
+
+func TestGetCompleteBaseImageVersionSchemaV2(t *testing.T) {
+	expectedVersion := "8.152.18"
+
+	server, err := startMockRegistryManifestServer("testdata/aurora_flange_manifest_v2.json", "testdata/aurora_flange_container_image_v1.json")
+
+	defer server.Close()
+
+	assert.NoError(t, err)
+
+	target := NewRegistryClient(server.URL)
+
+	actualVersion, err := target.GetCompleteBaseImageVersion(repository, tag)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedVersion, actualVersion)
+}
+
+func TestGetManifestEnvMapSchemaV2(t *testing.T) {
+	expectedLength := 13
+
+	server, err := startMockRegistryManifestServer("testdata/aurora_flange_manifest_v2.json", "testdata/aurora_flange_container_image_v1.json")
+
+	defer server.Close()
+
+	assert.NoError(t, err)
+
+	target := NewRegistryClient(server.URL)
+
+	envMap, err := target.GetManifestEnvMap(repository, tag)
+
+	assert.NoError(t, err)
+
+	actualLength := len(envMap)
+	assert.Equal(t, expectedLength, actualLength)
 }
 
 func TestGetTags(t *testing.T) {
@@ -103,6 +171,43 @@ func startMockRegistryServer(filename string) (*httptest.Server, error) {
 	}
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(buf)))
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Write(buf)
+	}))
+	ts.StartTLS()
+	return ts, nil
+}
+
+
+func startMockRegistryManifestServer(fileManifest string, fileImageMeta string) (*httptest.Server, error) {
+	bufManifest, err := ioutil.ReadFile(fileManifest)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bufImageMeta, err := ioutil.ReadFile(fileImageMeta)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bufManifestError, err := ioutil.ReadFile("testdata/aurora_flange_manifest_error.json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf []byte
+		if strings.Contains(r.Header.Get("Accept"), httpHeaderManifestSchemaV2) {
+			buf = bufManifest
+		} else if strings.Contains(r.Header.Get("Accept"), httpHeaderContainerImageV1) {
+			buf = bufImageMeta
+		} else  {
+			buf = bufManifestError
+		}
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(buf)))
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.Write(buf)

--- a/pkg/docker/testdata/aurora_flange_container_image_v1.json
+++ b/pkg/docker/testdata/aurora_flange_container_image_v1.json
@@ -1,0 +1,212 @@
+{
+  "architecture": "amd64",
+  "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+  "config": {
+    "Hostname": "eec77054e766",
+    "Domainname": "",
+    "User": "",
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "AttachStderr": false,
+    "Tty": false,
+    "OpenStdin": false,
+    "StdinOnce": false,
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/jre/bin",
+      "JAVA_HOME=/jre",
+      "JAVA_VERSION_MAJOR=8",
+      "JAVA_VERSION_MINOR=152",
+      "JAVA_VERSION_BUILD=16",
+      "JAVA_PACKAGE=server-jre",
+      "LANG=C.UTF-8",
+      "HOME=/u01",
+      "JOLOKIA_VERSION=1.3.7",
+      "JOLOKIA_PATH=/opt/jolokia/jolokia-jvm-1.3.7-agent.jar",
+      "BASE_IMAGE_VERSION=8.152.18",
+      "ALPINE_VERSION=3.6",
+      "TRUST_STORE=/jre/lib/security/cacerts"
+    ],
+    "Cmd": [
+      "/u01/bin/run"
+    ],
+    "ArgsEscaped": true,
+    "Image": "sha256:1b56263b8d8fe7a7e237824c4d635471c1efd1ec0b97609c22ea181e84e8da63",
+    "Volumes": null,
+    "WorkingDir": "/u01",
+    "Entrypoint": [
+      "/usr/bin/dumb-init",
+      "--"
+    ],
+    "OnBuild": [],
+    "Labels": {
+      "alpine": "3.6",
+      "java": "oraclejdk-8u152-b16",
+      "jolokia": "",
+      "version": "8.152.18"
+    }
+  },
+  "container": "8b6ba02286f3657695a547e8e179d5034f0be2bd38be1d53a0ce20ed165e7556",
+  "container_config": {
+    "Hostname": "eec77054e766",
+    "Domainname": "",
+    "User": "",
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "AttachStderr": false,
+    "Tty": false,
+    "OpenStdin": false,
+    "StdinOnce": false,
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/jre/bin",
+      "JAVA_HOME=/jre",
+      "JAVA_VERSION_MAJOR=8",
+      "JAVA_VERSION_MINOR=152",
+      "JAVA_VERSION_BUILD=16",
+      "JAVA_PACKAGE=server-jre",
+      "LANG=C.UTF-8",
+      "HOME=/u01",
+      "JOLOKIA_VERSION=1.3.7",
+      "JOLOKIA_PATH=/opt/jolokia/jolokia-jvm-1.3.7-agent.jar",
+      "BASE_IMAGE_VERSION=8.152.18",
+      "ALPINE_VERSION=3.6",
+      "TRUST_STORE=/jre/lib/security/cacerts"
+    ],
+    "Cmd": [
+      "/bin/sh",
+      "-c",
+      "#(nop) ",
+      "CMD [\"/u01/bin/run\"]"
+    ],
+    "ArgsEscaped": true,
+    "Image": "sha256:1b56263b8d8fe7a7e237824c4d635471c1efd1ec0b97609c22ea181e84e8da63",
+    "Volumes": null,
+    "WorkingDir": "/u01",
+    "Entrypoint": [
+      "/usr/bin/dumb-init",
+      "--"
+    ],
+    "OnBuild": [],
+    "Labels": {
+      "alpine": "3.6",
+      "java": "oraclejdk-8u152-b16",
+      "jolokia": "",
+      "version": "8.152.18"
+    }
+  },
+  "created": "2017-11-29T13:24:51.39994058Z",
+  "docker_version": "1.12.6",
+  "history": [
+    {
+      "created": "2017-11-03T22:10:18.456471742Z",
+      "created_by": "/bin/sh -c #(nop) ADD file:1e87ff33d1b6765b793888cd50e01b2bd0dfe152b7dbb4048008bfc2658faea7 in / "
+    },
+    {
+      "created": "2017-11-03T22:10:18.605674287Z",
+      "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:06:17.548819868Z",
+      "created_by": "/bin/sh -c #(nop)  ARG javaMajorVersion=8",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:06:18.390965776Z",
+      "created_by": "/bin/sh -c #(nop)  ARG javaMinorVersion",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:06:19.319900135Z",
+      "created_by": "/bin/sh -c #(nop)  ARG javaBuildVersion",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:06:20.234867632Z",
+      "created_by": "/bin/sh -c #(nop)  ARG javaHash",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:06:21.552818159Z",
+      "created_by": "/bin/sh -c #(nop)  ARG jolokiaVersion",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:06:22.555831204Z",
+      "created_by": "/bin/sh -c #(nop)  ARG baseImageVersion",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:06:23.528974468Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop)  MAINTAINER The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:06:24.343960326Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop)  ENV JAVA_HOME=/jre",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:24:03.04893657Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop)  ENV JAVA_VERSION_MAJOR=8 JAVA_VERSION_MINOR=152 JAVA_VERSION_BUILD=16 JAVA_PACKAGE=server-jre PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/jre/bin LANG=C.UTF-8 HOME=/u01 JOLOKIA_VERSION=1.3.7 JOLOKIA_PATH=/opt/jolokia/jolokia-jvm-1.3.7-agent.jar BASE_IMAGE_VERSION=8.152.18 ALPINE_VERSION=3.6 TRUST_STORE=/jre/lib/security/cacerts",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:24:05.027832971Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop)  LABEL java=oraclejdk-8u152-b16 alpine=3.6 jolokia= version=8.152.18",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:24:07.110822879Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop) ADD dir:93b313f230b5b3d1dc42a10532a1696a3ddf5aaae62652ce4e4b2e1e245ab470 in /opt/jolokia "
+    },
+    {
+      "created": "2017-11-29T13:24:43.361555516Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "|6 baseImageVersion=8.152.18 javaBuildVersion=16 javaHash=aa0333dd3019491ca4f6ddbe78cdb6d0 javaMajorVersion=8 javaMinorVersion=152 jolokiaVersion=1.3.7 /bin/sh -c chmod -R 777 /opt/jolokia &&     apk add --update curl ca-certificates &&     cd /tmp &&     curl -k -L -o glibc-2.23-r1.apk https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-2.23-r1.apk &&     curl -k -L -o glibc-bin-2.23-r1.apk https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-bin-2.23-r1.apk &&     apk add --allow-untrusted         glibc-2.23-r1.apk         glibc-bin-2.23-r1.apk &&     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf &&     curl -jksSLH \"Cookie: oraclelicense=accept-securebackup-cookie\"           \"http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${javaHash}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz\"           | gunzip -c - | tar -xf - &&     mv jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR}/jre /jre &&     curl -jkSLH \"Cookie: oraclelicense=accept-securebackup-cookie\"         \"http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip\" > jce_policy.zip  &&     unzip jce_policy.zip &&     cp UnlimitedJCEPolicyJDK8/local_policy.jar /jre/lib/security/ &&     cp UnlimitedJCEPolicyJDK8/US_export_policy.jar /jre/lib/security/ &&     rm jce_policy.zip &&     rm -r UnlimitedJCEPolicyJDK8 &&     apk del curl ca-certificates &&     rm /jre/bin/jjs &&     rm /jre/bin/keytool &&     rm /jre/bin/orbd &&     rm /jre/bin/pack200 &&     rm /jre/bin/rmid &&     rm /jre/bin/rmiregistry &&     rm /jre/bin/servertool &&     rm /jre/bin/tnameserv &&     rm /jre/bin/unpack200 &&     rm /jre/lib/ext/nashorn.jar &&     rm /jre/lib/jfr.jar &&     rm -rf /jre/lib/jfr &&     rm -rf /jre/lib/oblique-fonts &&     apk add --no-cache       dumb-init       drill       tcpdump       ngrep       bash       tzdata &&     mkdir $HOME &&     rm -rf /tmp/* /var/cache/apk/*"
+    },
+    {
+      "created": "2017-11-29T13:24:45.502910273Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop) ADD dir:28c95dc23a7d5557b255bc19ab929279a0d40ff6bbddea9adb00b9545390626b in /u01/bin "
+    },
+    {
+      "created": "2017-11-29T13:24:47.147862375Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "|6 baseImageVersion=8.152.18 javaBuildVersion=16 javaHash=aa0333dd3019491ca4f6ddbe78cdb6d0 javaMajorVersion=8 javaMinorVersion=152 jolokiaVersion=1.3.7 /bin/sh -c chmod -R 777 $HOME"
+    },
+    {
+      "created": "2017-11-29T13:24:48.455829733Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop)  WORKDIR /u01",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:24:49.692903098Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop)  ENTRYPOINT [\"/usr/bin/dumb-init\" \"--\"]",
+      "empty_layer": true
+    },
+    {
+      "created": "2017-11-29T13:24:51.39994058Z",
+      "author": "The Norwegian Tax Administration <utvpaas@skatteetaten.no>",
+      "created_by": "/bin/sh -c #(nop)  CMD [\"/u01/bin/run\"]",
+      "empty_layer": true
+    }
+  ],
+  "os": "linux",
+  "rootfs": {
+    "type": "layers",
+    "diff_ids": [
+      "sha256:2aebd096e0e237b447781353379722157e6c2d434b9ec5a0d63f2a6f07cf90c2",
+      "sha256:d017c4b2103204f4192f42c8e89a478e605e22cc4f080577105c8be5a8ec59e9",
+      "sha256:5ab2b8586ec7407d075acce172c51b9993bbb87effddbe0564bf17894e8ea42b",
+      "sha256:ca6de00d81ff069947e4e9e871e7fc1c8387f9d717c73283b6161b24443fffe0",
+      "sha256:0bd78f8a8634517a374bcaa96711930920e7fdf7fe4a39f145e8c0c13fdac7bc"
+    ]
+  }
+}

--- a/pkg/docker/testdata/aurora_flange_manifest_error.json
+++ b/pkg/docker/testdata/aurora_flange_manifest_error.json
@@ -1,0 +1,16 @@
+{
+  "errors": [
+    {
+      "code": "MANIFEST_UNKNOWN",
+      "message": "manifest unknown",
+      "detail": [
+        {
+          "Name": "aurora/flange"
+        },
+        {
+          "Revision": "sha256:b6a7c668428ff9347ef5c4f8736e8b7f38696dc6acc74409627d3607520"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/docker/testdata/aurora_flange_manifest_v2.json
+++ b/pkg/docker/testdata/aurora_flange_manifest_v2.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+  "config": {
+    "mediaType": "application/vnd.docker.container.image.v1+json",
+    "size": 8630,
+    "digest": "sha256:b6a7c668428ff9347ef5c4f8736e8b7f38696dc6acc74409627d360752017fcc"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 1991435,
+      "digest": "sha256:b56ae66c29370df48e7377c8f9baa744a3958058a766793f821dadcb144a4647"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 401032,
+      "digest": "sha256:8782ca8df83d0a1e8307090e7461f874df1b0d3e009b76ae7d0893372774d031"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 45850469,
+      "digest": "sha256:e4ca4193dea43338ac0ecf828e231dd85f1f9a00e6d6279ac5190b72716af31a"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 2404,
+      "digest": "sha256:489ddd698dbc5702cf82202becdc231f48dcb96ca4cce37a2992ca917ff777cf"
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 2397,
+      "digest": "sha256:bee4bd9ac27079f126c9c4e85643b722572b4d862dd0a40d1b25a078664034c6"
+    }
+  ]
+}

--- a/pkg/docker/utils.go
+++ b/pkg/docker/utils.go
@@ -1,12 +1,12 @@
 package docker
 
 import (
-	"github.com/skatteetaten/architect/pkg/config/runtime"
-	"time"
 	"crypto/tls"
+	"github.com/pkg/errors"
+	"github.com/skatteetaten/architect/pkg/config/runtime"
 	"io/ioutil"
 	"net/http"
-	"github.com/pkg/errors"
+	"time"
 )
 
 // CreateCompleteTagsFromSpecAndTags makes a target image to be used for push.

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -1,6 +1,7 @@
 package nexus
 
 import (
+	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 	"github.com/skatteetaten/architect/pkg/config"
 	"io"
@@ -12,7 +13,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"github.com/Sirupsen/logrus"
 )
 
 type Downloader interface {

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"github.com/Sirupsen/logrus"
 )
 
 type Downloader interface {
@@ -59,6 +60,7 @@ func (n *NexusDownloader) DownloadArtifact(c *config.MavenGav) (Deliverable, err
 		return deliverable, errors.Wrapf(err, "Failed to create Nexus url for GAV %+v", c)
 	}
 
+	logrus.Debugf("Downloading artifact from %s", resourceUrl)
 	httpResponse, err := http.Get(resourceUrl)
 	if err != nil {
 		return deliverable, errors.Wrapf(err, "Failed to get artifact from Nexus %s", resourceUrl)
@@ -97,6 +99,7 @@ func (n *NexusDownloader) DownloadArtifact(c *config.MavenGav) (Deliverable, err
 		return deliverable, errors.Wrap(err, "Failed to write to artifact file")
 	}
 	deliverable.Path = fileName
+	logrus.Debugf("Downloaded artifact to %s", deliverable.Path)
 	return deliverable, nil
 }
 


### PR DESCRIPTION
Rewrite to support schema version 1 and 2 against registry. 
Also removed strict validation for manifest schema version 1. 