### PR TITLE
Custom headere

### DIFF
--- a/pkg/nodejs/prepare/openshiftjson_test.go
+++ b/pkg/nodejs/prepare/openshiftjson_test.go
@@ -1,0 +1,80 @@
+package prepare
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const OPENSHIFT_JSON_NEW_FORMAT = `
+{
+    "web": {
+        "webapp": { 
+            "path": "/",
+            "content": "build"
+        },
+        "nodejs": {
+            "main": "api/server.js"
+        }
+    }
+}`
+
+const OPENSHIFT_JSON_LEGACY_FORMAT = `
+{
+    "web": {
+        "spa": true,
+        "path": "/",
+        "static": "build",
+        "nodejs": {
+            "main": "api/server.js"
+        }
+    }
+}`
+
+const OPENSHIFT_JSON_NEW_FORMAT_SPA_NOT_SET = `
+{
+    "web": {
+        "webapp": {
+            "headers": {
+                "X-Frame-Options": "sameorigin"
+            },
+            "path": "/",
+            "content": "build", 
+            "disableTryfiles": false
+        },
+        "nodejs": {
+            "main": "api/server.js"
+        }
+    }
+}`
+
+func TestThatSpaDefaultToTrueInWebAppBlock(t *testing.T) {
+	openshiftJson := openshiftJson{}
+	assert.NoError(t, json.Unmarshal([]byte(OPENSHIFT_JSON_NEW_FORMAT), &openshiftJson))
+	assert.NotNil(t, openshiftJson.Aurora.Webapp)
+	assert.False(t, openshiftJson.Aurora.Webapp.DisableTryfiles)
+}
+
+func TestThatValuesAreSetAsExpected(t *testing.T) {
+	openshiftJson := openshiftJson{}
+	assert.NoError(t, json.Unmarshal([]byte(OPENSHIFT_JSON_NEW_FORMAT_SPA_NOT_SET), &openshiftJson))
+	assert.NotNil(t, openshiftJson.Aurora.Webapp)
+	assert.False(t, openshiftJson.Aurora.Webapp.DisableTryfiles)
+	assert.Equal(t, openshiftJson.Aurora.Webapp.Headers["X-Frame-Options"], "sameorigin")
+	assert.Equal(t, openshiftJson.Aurora.Webapp.Path, "/")
+	assert.Equal(t, openshiftJson.Aurora.Webapp.StaticContent, "build")
+}
+
+func TestThatLegacyFormatIsMappedCorrect(t *testing.T) {
+	oldOpenShiftJson := openshiftJson{}
+	newOpenShiftJson := openshiftJson{}
+	oldOpenShiftJson.Aurora.SPA = true
+	assert.NoError(t, json.Unmarshal([]byte(OPENSHIFT_JSON_NEW_FORMAT), &newOpenShiftJson))
+	assert.NoError(t, json.Unmarshal([]byte(OPENSHIFT_JSON_LEGACY_FORMAT), &oldOpenShiftJson))
+	tiOld := mapOpenShiftJsonToTemplateInput(&oldOpenShiftJson, "name", "name", "version")
+	tiNew := mapOpenShiftJsonToTemplateInput(&newOpenShiftJson, "name", "name", "version")
+	assert.EqualValues(t, tiNew, tiOld)
+	assert.Equal(t, "/", tiNew.Path)
+	assert.Equal(t, "build", tiNew.Static)
+	assert.Equal(t, true, tiNew.SPA)
+}

--- a/pkg/nodejs/prepare/tarball.go
+++ b/pkg/nodejs/prepare/tarball.go
@@ -87,7 +87,7 @@ func writeInternal(deferrerd func() (string, error)) (string, error) {
 	return deferrerd()
 }
 
-func findOpenshiftJsonInTarball(pathToTarball string) (*OpenshiftJson, error) {
+func findOpenshiftJsonInTarball(pathToTarball string) (*openshiftJson, error) {
 	tarball, err := os.Open(pathToTarball)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error opening tarball")
@@ -114,7 +114,7 @@ func findOpenshiftJsonInTarball(pathToTarball string) (*OpenshiftJson, error) {
 		}
 
 		if header.Typeflag == tar.TypeReg && header.Name == "package/metadata/openshift.json" {
-			v := &OpenshiftJson{}
+			v := &openshiftJson{}
 			err := json.NewDecoder(tarReader).Decode(v)
 			if err != nil {
 				return nil, errors.Wrap(err, "Error reading openshift.json")

--- a/pkg/nodejs/prepare/types.go
+++ b/pkg/nodejs/prepare/types.go
@@ -1,0 +1,62 @@
+package prepare
+
+import "github.com/skatteetaten/architect/pkg/config/runtime"
+
+type auroraApplication struct {
+	NodeJS *nodeJSApplication `json:"nodejs"`
+	//Deprecated
+	Static            string          `json:"static"`
+	Webapp            *webApplication `json:"webapp"`
+	ConfigurableProxy bool            `json:"configurableProxy"`
+	//Deprecated
+	Path string `json:"path"`
+	//Deprecated
+	SPA bool `json:"spa"`
+}
+
+type webApplication struct {
+	StaticContent   string            `json:"content"`
+	Path            string            `json:"path"`
+	Headers         map[string]string `json:"headers"`
+	DisableTryfiles bool              `json:"disableTryfiles"`
+}
+
+type nodeJSApplication struct {
+	Main    string `json:"main"`
+	Waf     string `json:"waf"`
+	Runtime string `json:"runtime"`
+}
+
+type openshiftJson struct {
+	Aurora         auroraApplication `json:"web"`
+	DockerMetadata dockerMetadata    `json:"docker"`
+}
+
+type dockerMetadata struct {
+	Maintainer string            `json:"maintainer"`
+	Labels     map[string]string `json:"labels"`
+}
+
+type PreparedImage struct {
+	baseImage runtime.DockerImage
+	Path      string
+}
+
+type probe struct {
+	Include bool
+	Port    int
+}
+
+type templateInput struct {
+	Baseimage            string
+	MainFile             string
+	HasNodeJSApplication bool
+	ConfigurableProxy    bool
+	Static               string
+	SPA                  bool
+	ExtraStaticHeaders   map[string]string
+	Path                 string
+	Labels               map[string]string
+	PackageDirectory     string
+	ImageBuildTime       string
+}


### PR DESCRIPTION
Har endret formatet på openshift.json. Endringene er bakoverkompatible.

Jeg ser det kommer mer og mer i static-blokken. 

Det som tidligere var:
```json 
{ 
 "web": {
        "nodejs": {
            "main": "api/server.js"
          },
        "static": "build",
        "spa": true
    }
}
```

blir nå:
```json
{  
  "web": {
        "nodejs": {
            "main": "api/server.js"
          },
        "staticApp": {
             "staticContent": "build",
             "spa": true,
             "extraHeaders": {
                 "X-Frame-Options" : "sameorigin"
              }
    }
}
```

Ny funksjonalitet blir kun lagt til i staticApp-blokken.

Diskuterer gjerne navngiving, men jeg tror det er lurt å skille de to. Det er endel konfigoptions som er på toppnivå nå (som "spa") som ikke burde vært det. Jeg er litt usikker på path.. Vi trenger den på statisk innhold, men ikke på dynamisk slik ting er nå.