### PR TITLE
Fixed regexp in application.go

### DIFF
--- a/pkg/nodejs/prepare/application.go
+++ b/pkg/nodejs/prepare/application.go
@@ -117,7 +117,7 @@ For example; Accepting very large client_max_body_size would make a DOS attack v
 var allowedNginxOverrides = map[string]func(string) error{
 	"client_max_body_size": func(s string) error {
 		// between 1 and 20
-		match, err := regexp.MatchString("^([1-9]|[1-2][0-9])m$", s)
+		match, err := regexp.MatchString("^([1-9]|[1][0-9]|[2][0])m$", s)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixed regexp to match 1-20 instead of 1-29