### PR TITLE
AOT-217: web.webapp.path mappes ikke til root på Nginx

### DIFF
--- a/pkg/nodejs/prepare/application.go
+++ b/pkg/nodejs/prepare/application.go
@@ -265,12 +265,13 @@ func mapOpenShiftJsonToTemplateInput(v *openshiftJson, completeDockerName string
 	labels["version"] = string(auroraVersion.GetAppVersion())
 	labels["maintainer"] = findMaintainer(v.DockerMetadata)
 
-	var path string
-	if len(strings.TrimPrefix(v.Aurora.Path, "/")) == 0 {
-		path = "/"
-	} else {
+	path := "/"
+	if v.Aurora.Webapp != nil && len(strings.TrimPrefix(v.Aurora.Webapp.Path, "/")) > 0 {
+		path = "/" + strings.TrimPrefix(v.Aurora.Webapp.Path, "/")
+	} else if len(strings.TrimPrefix(v.Aurora.Path, "/")) > 0 {
+		logrus.Warnf("web.path in openshift.json is deprecated. Please use web.webapp.path when setting path: %s", v.Aurora.Path)
 		path = "/" + strings.TrimPrefix(v.Aurora.Path, "/")
-	}
+	} 
 
 	if !strings.HasSuffix(path, "/") {
 		path = path + "/"


### PR DESCRIPTION
Ligger støtte for både web.path og web.webapp.path. Dersom bruk av web.path så skrives det ut en warning, så får vi det opp i splunk. Når bruken av web.path er =0 så kan vi fjerne støtten for web.path helt og kun bruke web.webapp.path. 