### PR TITLE
Lagt inn håndtering av root gzip + locations som en del av radish.json

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func initializeAndRunOnOpenShift() {
 	if c.BinaryBuild {
 		binaryInput, err := util.ExtractBinaryFromStdIn()
 		if err != nil {
-			logrus.Fatalf("Could not read binary input", err)
+			logrus.Fatalf("Could not read binary input: %s", err)
 		}
 		nexusDownloader = nexus.NewBinaryDownloader(binaryInput)
 	} else {

--- a/pkg/nodejs/prepare/application.go
+++ b/pkg/nodejs/prepare/application.go
@@ -206,24 +206,29 @@ func mapOpenShiftJsonToTemplateInput(dockerSpec config.DockerSpec, v *openshiftJ
 	}
 
 	var exclude []string
-	if v.Aurora.Exclude != nil {
-		for _, value := range v.Aurora.Exclude {
-			exclude = append(exclude, value)
-		}
-	}
-
 	var static string
 	var spa bool
 	var extraHeaders map[string]string
+	var gZip = nginxGzip{}
+	var nginxLocationMap = make(nginxLocations)
 	if v.Aurora.Webapp == nil {
 		static = v.Aurora.Static
 		spa = v.Aurora.SPA
+		exclude = nil
 		extraHeaders = nil
-
+		nginxLocationMap = nil
 	} else {
 		static = v.Aurora.Webapp.StaticContent
 		spa = v.Aurora.Webapp.DisableTryfiles == false
 		extraHeaders = v.Aurora.Webapp.Headers
+		gZip = v.Aurora.Webapp.Gzip
+		nginxLocationMap = buildNginxLocations(v.Aurora.Webapp.Locations)
+
+		if v.Aurora.Webapp.Exclude != nil {
+			for _, value := range v.Aurora.Webapp.Exclude {
+				exclude = append(exclude, value)
+			}
+		}
 	}
 
 	env := make(map[string]string)
@@ -247,6 +252,8 @@ func mapOpenShiftJsonToTemplateInput(dockerSpec config.DockerSpec, v *openshiftJ
 			SPA:                  spa,
 			Content:              static,
 			Exclude:              exclude,
+			Gzip:                 gZip,
+			Locations:            nginxLocationMap,
 		}, &DockerfileData{
 			Main:             nodejsMainfile,
 			Maintainer:       findMaintainer(v.DockerMetadata),
@@ -257,6 +264,43 @@ func mapOpenShiftJsonToTemplateInput(dockerSpec config.DockerSpec, v *openshiftJ
 			Env:              env,
 			Path:             path,
 		}, nil
+}
+
+func buildNginxLocations(locations map[string]interface{}) nginxLocations {
+	if locations == nil || len(locations) == 0 {
+		return nil
+	}
+
+	var nginxLocationMap = make(nginxLocations)
+
+	for locKey, locValue := range locations {
+		myMap := locValue.(map[string]interface{})
+		gZip := nginxGzip{}
+
+		if val, ok := myMap["gzip"]; ok {
+			gzipMap := val.(map[string]interface{})
+			if val, ok := gzipMap["use"]; ok {
+				gZip.Use = val.(string)
+			}
+
+			if val, ok := gzipMap["min_length"]; ok {
+				gZip.MinLength = int(val.(float64))
+			}
+
+			if val, ok := gzipMap["vary"]; ok {
+				gZip.Vary = val.(string)
+			}
+		}
+
+		headersMap := make(map[string]string)
+		if val, ok := myMap["headers"]; ok {
+			for headerKey, headerValue := range val.(map[string]interface{}) {
+				headersMap[headerKey] = headerValue.(string)
+			}
+		}
+		nginxLocationMap[locKey] = &nginxLocation{headersMap, gZip}
+	}
+	return nginxLocationMap
 }
 
 func whitelistOverrides(overrides map[string]string) error {

--- a/pkg/nodejs/prepare/nginx.go
+++ b/pkg/nodejs/prepare/nginx.go
@@ -9,6 +9,8 @@ type NginxfileData struct {
 	SPA                  bool
 	Content              string
 	Exclude              []string
+	Gzip                 nginxGzip
+	Locations            nginxLocations
 }
 
 const NGINX_CONFIG_TEMPLATE string = `

--- a/pkg/nodejs/prepare/openshiftjson_test.go
+++ b/pkg/nodejs/prepare/openshiftjson_test.go
@@ -50,6 +50,99 @@ const OPENSHIFT_JSON_NEW_FORMAT_SPA_NOT_SET = `
     }
 }`
 
+const openshiftJsonJSONWithLocations = `
+{
+	"docker": {
+	  "maintainer": "Aurora OpenShift Utvikling <utvpaas@skatteetaten.no>",
+	  "labels": {
+		 "io.k8s.description": "Demo application with React on Openshift.",
+		 "io.openshift.tags": "openshift,react,nodejs"
+	  }
+	},
+	"web": {
+	  "nodejs": {
+		 "assets": "api",
+		 "main": "api/server.js",
+		 "waf": "aurora-standard",
+		 "runtime": "nodeLTS"
+	  },
+	  "webapp": {
+		 "content": "app",
+		 "gzip": {
+			"use": "on",
+			"min_length": 2048,
+			"vary": "on"
+		 },
+		 "headers": {
+			"X-Some-Header": "Verdi"
+		 },
+		 "locations": {
+			"index.html": {
+			  "headers": {
+				 "Cache-Control": "no-cache",
+				 "X-XSS-Protection": "1",
+				 "X-Frame-Options": "DENY"
+			  },
+			  "gzip": {
+				 "use": "on",
+				 "min_length": 1024,
+				 "vary": "on"
+			  }
+			},
+			"index_other.html": {
+			  "headers": {
+				 "Cache-Control": "max-age=60",
+				 "X-XSS-Protection": "0"
+			  },
+			  "gzip": {
+				 "use": "off"
+			  }
+			},
+			"index/other.html": {
+				"headers": {
+				   "Cache-Control": "no-store",
+				   "X-XSS-Protection": "1; mode=block"
+				}
+			}
+		 },
+		 "static": "app"
+	  }
+	}
+ } 
+`
+
+const openshiftJsonJSONWithNoLocations = `
+{
+	"docker": {
+	  "maintainer": "Aurora OpenShift Utvikling <utvpaas@skatteetaten.no>",
+	  "labels": {
+		 "io.k8s.description": "Demo application with React on Openshift.",
+		 "io.openshift.tags": "openshift,react,nodejs"
+	  }
+	},
+	"web": {
+	  "nodejs": {
+		 "assets": "api",
+		 "main": "api/server.js",
+		 "waf": "aurora-standard",
+		 "runtime": "nodeLTS"
+	  },
+	  "webapp": {
+		 "content": "app",
+		 "gzip": {
+			"use": "on",
+			"min_length": 2048,
+			"vary": "on"
+		 },
+		 "headers": {
+			"X-Some-Header": "Verdi"
+		 },
+		 "static": "app"
+	  }
+	}
+ } 
+`
+
 func TestThatSpaDefaultToTrueInWebAppBlock(t *testing.T) {
 	openshiftJson := openshiftJson{}
 	assert.NoError(t, json.Unmarshal([]byte(OPENSHIFT_JSON_NEW_FORMAT), &openshiftJson))
@@ -96,20 +189,20 @@ func TestThatOverridesAreWhitelistedAndSetCorrectly(t *testing.T) {
 func TestThatExcludeIsSetCorrectly(t *testing.T) {
 	openshiftJson := openshiftJson{}
 	assert.NoError(t, json.Unmarshal([]byte(OPENSHIFT_JSON_NEW_FORMAT), &openshiftJson))
-	openshiftJson.Aurora.Exclude = []string{
+	openshiftJson.Aurora.Webapp.Exclude = []string{
 		"test/test1.swf",
 		"test/test2.swf",
 	}
 	nginxConf, _, err := mapObject(&openshiftJson)
 
 	assert.NoError(t, err)
-	assert.Equal(t, openshiftJson.Aurora.Exclude, nginxConf.Exclude)
+	assert.Equal(t, openshiftJson.Aurora.Webapp.Exclude, nginxConf.Exclude)
 }
 
 func TestThatExcludeRegExIsValid(t *testing.T) {
 	openshiftJson := openshiftJson{}
 	assert.NoError(t, json.Unmarshal([]byte(OPENSHIFT_JSON_NEW_FORMAT), &openshiftJson))
-	openshiftJson.Aurora.Exclude = []string{
+	openshiftJson.Aurora.Webapp.Exclude = []string{
 		"(.*myapp)/(.+\\.php)$",
 		".+\\.(?<ext>.*)$",
 		"~*.+\\.(.+)$",
@@ -122,7 +215,7 @@ func TestThatExcludeRegExIsInvalid(t *testing.T) {
 	t.SkipNow()
 	openshiftJson := openshiftJson{}
 	assert.NoError(t, json.Unmarshal([]byte(OPENSHIFT_JSON_NEW_FORMAT), &openshiftJson))
-	openshiftJson.Aurora.Exclude = []string{
+	openshiftJson.Aurora.Webapp.Exclude = []string{
 		"(.mya*pp)/(+\\.php)$",
 	}
 	_, _, err := mapObject(&openshiftJson)
@@ -146,6 +239,79 @@ func TestThatLegacyFormatIsMappedCorrect(t *testing.T) {
 	assert.Equal(t, "/", nNew.Path)
 	assert.Equal(t, "build", dNew.Static)
 	assert.Equal(t, true, nNew.SPA)
+}
+
+func TestThatRootGzipIsPresentInNginx(t *testing.T) {
+	openshiftJson := openshiftJson{}
+	assert.NoError(t, json.Unmarshal([]byte(openshiftJsonJSONWithLocations), &openshiftJson))
+	nginxfileData, _, err := mapObject(&openshiftJson)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, nginxfileData.Gzip)
+	assert.Equal(t, "on", nginxfileData.Gzip.Use)
+	assert.Equal(t, 2048, nginxfileData.Gzip.MinLength)
+	assert.Equal(t, "on", nginxfileData.Gzip.Vary)
+	assert.Equal(t, "", nginxfileData.Gzip.Proxied)
+	assert.Equal(t, "", nginxfileData.Gzip.Types)
+	assert.Equal(t, "", nginxfileData.Gzip.Disable)
+}
+
+func TestThatCustomLocationsIsPresentInNginx(t *testing.T) {
+	openshiftJson := openshiftJson{}
+	assert.NoError(t, json.Unmarshal([]byte(openshiftJsonJSONWithLocations), &openshiftJson))
+	nginxfileData, _, err := mapObject(&openshiftJson)
+
+	assert.NoError(t, err)	
+	assert.Equal(t, 3, len(nginxfileData.Locations))
+
+	// Test index.html configuration
+	assert.Equal(t, 3, len(nginxfileData.Locations["index.html"].Headers))
+	assert.Equal(t, "no-cache", nginxfileData.Locations["index.html"].Headers["Cache-Control"])
+	assert.Equal(t, "1", nginxfileData.Locations["index.html"].Headers["X-XSS-Protection"])
+	assert.Equal(t, "DENY", nginxfileData.Locations["index.html"].Headers["X-Frame-Options"])
+
+	assert.NotNil(t, nginxfileData.Locations["index.html"].Gzip)
+	assert.Equal(t, "on", nginxfileData.Locations["index.html"].Gzip.Use)
+	assert.Equal(t, 1024, nginxfileData.Locations["index.html"].Gzip.MinLength)
+	assert.Equal(t, "on", nginxfileData.Locations["index.html"].Gzip.Vary)
+	assert.Equal(t, "", nginxfileData.Locations["index.html"].Gzip.Proxied)
+	assert.Equal(t, "", nginxfileData.Locations["index.html"].Gzip.Types)
+	assert.Equal(t, "", nginxfileData.Locations["index.html"].Gzip.Disable)
+
+	// Test index_other.html configuration
+	assert.Equal(t, 2, len(nginxfileData.Locations["index_other.html"].Headers))
+	assert.Equal(t, "max-age=60", nginxfileData.Locations["index_other.html"].Headers["Cache-Control"])
+	assert.Equal(t, "0", nginxfileData.Locations["index_other.html"].Headers["X-XSS-Protection"])
+
+	assert.NotNil(t, nginxfileData.Locations["index_other.html"].Gzip)
+	assert.Equal(t, "off", nginxfileData.Locations["index_other.html"].Gzip.Use)
+	assert.Equal(t, 0, nginxfileData.Locations["index_other.html"].Gzip.MinLength)
+	assert.Equal(t, "", nginxfileData.Locations["index_other.html"].Gzip.Vary)
+	assert.Equal(t, "", nginxfileData.Locations["index_other.html"].Gzip.Proxied)
+	assert.Equal(t, "", nginxfileData.Locations["index_other.html"].Gzip.Types)
+	assert.Equal(t, "", nginxfileData.Locations["index_other.html"].Gzip.Disable)
+
+	// Test index/other.html configuration
+	assert.Equal(t, 2, len(nginxfileData.Locations["index/other.html"].Headers))
+	assert.Equal(t, "no-store", nginxfileData.Locations["index/other.html"].Headers["Cache-Control"])
+	assert.Equal(t, "1; mode=block", nginxfileData.Locations["index/other.html"].Headers["X-XSS-Protection"])
+
+	assert.NotNil(t, nginxfileData.Locations["index/other.html"].Gzip)
+	assert.Equal(t, "", nginxfileData.Locations["index/other.html"].Gzip.Use)
+	assert.Equal(t, 0, nginxfileData.Locations["index/other.html"].Gzip.MinLength)
+	assert.Equal(t, "", nginxfileData.Locations["index/other.html"].Gzip.Vary)
+	assert.Equal(t, "", nginxfileData.Locations["index/other.html"].Gzip.Proxied)
+	assert.Equal(t, "", nginxfileData.Locations["index/other.html"].Gzip.Types)
+	assert.Equal(t, "", nginxfileData.Locations["index/other.html"].Gzip.Disable)
+}
+
+func TestThatNoCustomLocationsIsPresentInNginx(t *testing.T) {
+	openshiftJson := openshiftJson{}
+	assert.NoError(t, json.Unmarshal([]byte(openshiftJsonJSONWithNoLocations), &openshiftJson))
+	nginxfileData, _, err := mapObject(&openshiftJson)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(nginxfileData.Locations))
 }
 
 func mapObject(openshiftJson *openshiftJson) (*NginxfileData, *DockerfileData, error) {

--- a/pkg/nodejs/prepare/openshiftjson_test.go
+++ b/pkg/nodejs/prepare/openshiftjson_test.go
@@ -261,7 +261,7 @@ func TestThatCustomLocationsIsPresentInNginx(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(openshiftJsonJSONWithLocations), &openshiftJson))
 	nginxfileData, _, err := mapObject(&openshiftJson)
 
-	assert.NoError(t, err)	
+	assert.NoError(t, err)
 	assert.Equal(t, 3, len(nginxfileData.Locations))
 
 	// Test index.html configuration

--- a/pkg/nodejs/prepare/radish_config.go
+++ b/pkg/nodejs/prepare/radish_config.go
@@ -8,10 +8,12 @@ import (
 
 //Web :
 type Web struct {
-	ConfigurableProxy bool     `json:"configurableProxy"`
-	Nodejs            Nodejs   `json:"nodejs"`
-	WebApp            WebApp   `json:"webapp"`
-	Exclude           []string `json:"exclude"`
+	ConfigurableProxy bool           `json:"configurableProxy"`
+	Nodejs            Nodejs         `json:"nodejs"`
+	WebApp            WebApp         `json:"webapp"`
+	Gzip              nginxGzip      `json:"gzip"`
+	Exclude           []string       `json:"exclude"`
+	Locations         nginxLocations `json:"locations"`
 }
 
 //Nodejs :
@@ -54,7 +56,9 @@ func newRadishNginxConfig(docker *DockerfileData, nginx *NginxfileData) util.Wri
 					DisableTryfiles: !nginx.SPA,
 					Headers:         nginx.ExtraStaticHeaders,
 				},
-				Exclude: nginx.Exclude,
+				Gzip:      nginx.Gzip,
+				Exclude:   nginx.Exclude,
+				Locations: nginx.Locations,
 			},
 		}
 		err := json.NewEncoder(writer).Encode(data)

--- a/pkg/nodejs/prepare/types.go
+++ b/pkg/nodejs/prepare/types.go
@@ -8,7 +8,6 @@ type auroraApplication struct {
 	Static            string          `json:"static"`
 	Webapp            *webApplication `json:"webapp"`
 	ConfigurableProxy bool            `json:"configurableProxy"`
-	Exclude           []string        `json:"exclude"`
 	//Deprecated
 	Path string `json:"path"`
 	//Deprecated
@@ -16,10 +15,13 @@ type auroraApplication struct {
 }
 
 type webApplication struct {
-	StaticContent   string            `json:"content"`
-	Path            string            `json:"path"`
-	Headers         map[string]string `json:"headers"`
-	DisableTryfiles bool              `json:"disableTryfiles"`
+	StaticContent   string                 `json:"content"`
+	Path            string                 `json:"path"`
+	Headers         map[string]string      `json:"headers"`
+	Gzip            nginxGzip              `json:"gzip"`
+	Locations       map[string]interface{} `json:"locations"`
+	Exclude         []string               `json:"exclude"`
+	DisableTryfiles bool                   `json:"disableTryfiles"`
 }
 
 type nodeJSApplication struct {
@@ -45,6 +47,22 @@ type PreparedImage struct {
 type probe struct {
 	Include bool
 	Port    int
+}
+
+type nginxLocations map[string]*nginxLocation
+
+type nginxLocation struct {
+	Headers map[string]string `json:"headers"`
+	Gzip    nginxGzip         `json:"gzip"`
+}
+
+type nginxGzip struct {
+	Use       string `json:"use"`
+	MinLength int    `json:"min_length"`
+	Vary      string `json:"vary"`
+	Proxied   string `json:"proxied"`
+	Types     string `json:"types"`
+	Disable   string `json:"disable"`
 }
 
 type templateInput struct {


### PR DESCRIPTION
Jeg har tatt utgangspunkt i Tor Eriks' kode (https://github.com/Skatteetaten/architect/blob/feature/AOT-598/) og delt den opp, således data bliver mappet over i radish.json for å bli samlet opp der for ytterligere prosessering rundt oppbygning av nginx.conf filen.

Har primært testet denne gjennom de unit tests som er laget i forbindelse med oppgaven.

En komplett (real life) test vil blive kjørt sammen med Radish når den bit er klar...