### PR TITLE
AOS-5132 - Støtte Python bygg med Rumple39

### DIFF
--- a/pkg/doozer/prepare/dockerfile.go
+++ b/pkg/doozer/prepare/dockerfile.go
@@ -94,7 +94,7 @@ func NewDockerFile(dockerSpec global.DockerSpec, auroraVersion runtime.AuroraVer
 		env := createEnv(auroraVersion, dockerSpec.PushExtraTags, imageBuildTime)
 
 		dockerFileTemplate := dockerFileTemplateBody
-		if strings.Contains(baseImage.GetCompleteDockerTagName(), "rumple39") {
+		if strings.Contains(baseImage.GetCompleteDockerTagName(), "rumple") {
 			dockerFileTemplate += "RUN $HOME/application/bin/install-deps.sh\n"
 		}
 

--- a/pkg/doozer/prepare/dockerfile.go
+++ b/pkg/doozer/prepare/dockerfile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/skatteetaten/architect/pkg/doozer/config"
 	"github.com/skatteetaten/architect/pkg/util"
 	"io"
+	"strings"
 )
 
 var dockerFileTemplateBody string = `FROM {{.BaseImage}}
@@ -93,6 +94,10 @@ func NewDockerFile(dockerSpec global.DockerSpec, auroraVersion runtime.AuroraVer
 		env := createEnv(auroraVersion, dockerSpec.PushExtraTags, imageBuildTime)
 
 		dockerFileTemplate := dockerFileTemplateBody
+		if strings.Contains(baseImage.GetCompleteDockerTagName(), "rumple39") {
+			dockerFileTemplate += "RUN $HOME/application/bin/install-deps.sh\n"
+		}
+
 		if meta.Doozer.CmdScript != "" {
 			dockerFileTemplate += dockerFileTemplateCmd
 		}

--- a/pkg/doozer/prepare/dockerfile_test.go
+++ b/pkg/doozer/prepare/dockerfile_test.go
@@ -55,6 +55,30 @@ ENV APP_VERSION="0.0.1-SNAPSHOT" AURORA_VERSION="0.0.1-SNAPSHOT-bbuildimage-buil
 CMD ["./bin/somestartupcmd"]
 `
 
+const expectedDockerfileWithCmdScriptAndRumple = `FROM rumple39:latest
+
+MAINTAINER maintain@me.no
+LABEL maintainer="maintain.me.no" no.skatteetaten.test="TestLabel" randomlabel="Use the 4ce"
+
+# temp env hack until standard base image is available
+ENV LANG='en_US.UTF-8' \
+    TZ=Europe/Oslo \
+    HOME=/u01
+
+COPY ./app radish.json $HOME/
+COPY ./app/application/app/uberfile.war /path/to/your/destiny/uberfile.war
+
+RUN find $HOME/application -type d -exec chmod 755 {} + && \
+	find $HOME/application -type f -exec chmod 644 {} + && \
+	mkdir -p $HOME/logs && \
+	chmod 777 $HOME/logs && \
+	ln -s $HOME/logs $HOME/application/logs
+
+ENV APP_VERSION="0.0.1-SNAPSHOT" AURORA_VERSION="0.0.1-SNAPSHOT-bbuildimage-rumple39-latest" IMAGE_BUILD_TIME="2017-09-10T14:30:10Z" PUSH_EXTRA_TAGS="major" SNAPSHOT_TAG="0.0.1-SNAPSHOT" TZ="Europe/Oslo"
+RUN $HOME/application/bin/install-deps.sh
+CMD ["./bin/somestartupcmd"]
+`
+
 func TestBuild(t *testing.T) {
 	dockerSpec := global.DockerSpec{
 		PushExtraTags: global.ParseExtraTags("major"),
@@ -136,4 +160,45 @@ func TestBuildWithCmdScript(t *testing.T) {
 	assert.NoError(t, writer(buffer))
 	assert.Equal(t, expectedDockerfileWithCmdScript, buffer.String())
 
+}
+
+func TestBuildWithRumple(t *testing.T) {
+	dockerSpec := global.DockerSpec{
+		PushExtraTags: global.ParseExtraTags("major"),
+	}
+	baseImage := runtime.DockerImage{
+		Tag:        "latest",
+		Repository: "rumple39",
+	}
+	auroraVersions := runtime.NewAuroraVersionFromBuilderAndBase(
+		"0.0.1-SNAPSHOT",
+		true,
+		"0.0.1-SNAPSHOT",
+		&runtime.ArchitectImage{
+			Tag: "buildimage",
+		},
+		baseImage)
+
+	labels := make(map[string]string)
+	labels["no.skatteetaten.test"] = "TestLabel"
+	labels["maintainer"] = "maintain.me.no"
+	labels["randomlabel"] = "Use the 4ce"
+	deliverableMetadata := config.DeliverableMetadata{
+		Docker: &config.MetadataDocker{
+			Maintainer: "maintain@me.no",
+			Labels:     labels,
+		},
+		Doozer: &config.MetadataDoozer{
+			SrcPath:   "app/",
+			FileName:  "uberfile.war",
+			DestPath:  "/path/to/your/destiny/",
+			CmdScript: "./bin/somestartupcmd",
+		},
+	}
+	writer := prepare.NewDockerFile(dockerSpec, *auroraVersions, deliverableMetadata, baseImage, "2017-09-10T14:30:10Z", "")
+
+	buffer := new(bytes.Buffer)
+
+	assert.NoError(t, writer(buffer))
+	assert.Equal(t, expectedDockerfileWithCmdScriptAndRumple, buffer.String())
 }


### PR DESCRIPTION
Least effort offering to support Python apps with the current regime, with minimal changes. Enables serving python 3 apps in an image without modifying pipeline scripts or jenkins support, as well as easily building the leveransepakke with the gradle plugin, and building the image with architect using the doozer application type.

The constructed leveransepakke will look like this:

/src/<all app src>
/src/req.txt
/metadata/openshift.json

Doozer config will look like this:

  "doozer": {
    "srcPath": "src",
    "fileName": " ",
    "destPath": "$HOME/application/bin",
    "destFilename": " ",
    "cmdScript": "/u01/bin/run.sh"
  }

Things to consider for OCP4 and new architect:

- pip install must be run as part of build on jenkins, to produce a wheel-based dependency bundle (requires python on slave)
- pipeline must be updated for a python template (primarily to enable python on the slave)
- package must be uploaded to pypi registry, instead of standard maven
- architect must pull leveransepakke from pypi instead of standard maven