### PR TITLE
Feature/aos 5907 release binary build

### DIFF
--- a/cmd/architect/architect.go
+++ b/cmd/architect/architect.go
@@ -3,6 +3,11 @@ package architect
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/sirupsen/logrus"
 	"github.com/skatteetaten/architect/pkg/config"
 	"github.com/skatteetaten/architect/pkg/docker"
@@ -10,12 +15,8 @@ import (
 	java "github.com/skatteetaten/architect/pkg/java/prepare"
 	"github.com/skatteetaten/architect/pkg/nexus"
 	nodejs "github.com/skatteetaten/architect/pkg/nodejs/prepare"
-	"github.com/skatteetaten/architect/pkg/process/build"
+	process "github.com/skatteetaten/architect/pkg/process/build"
 	"github.com/skatteetaten/architect/pkg/process/retag"
-	"net/url"
-	"os"
-	"strings"
-	"time"
 )
 
 var verbose bool
@@ -112,12 +113,6 @@ func performBuild(ctx context.Context, configuration *RunConfiguration, c *confi
 	} else if c.ApplicationType == config.DoozerLeveranse {
 		logrus.Info("Perform Doozerleveranse build")
 		prepper = doozer.Prepper()
-	}
-
-	if !c.LocalBuild {
-		if c.BinaryBuild && !c.ApplicationSpec.MavenGav.IsSnapshot() {
-			logrus.Fatalf("Trying to build a release as binary build? Sorry, only SNAPSHOTS;)")
-		}
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, c.BuildTimeout*time.Second)

--- a/cmd/architect/architect.go
+++ b/cmd/architect/architect.go
@@ -117,6 +117,10 @@ func performBuild(ctx context.Context, configuration *RunConfiguration, c *confi
 		prepper = doozer.Prepper()
 	}
 
+	if c.BinaryBuild && c.BuildType == config.Snapshot && !c.ApplicationSpec.MavenGav.IsSnapshot() {
+		logrus.Fatalf("Can only build snapshots. Make version end with -SNAPSHOT")
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, c.BuildTimeout*time.Second)
 	defer cancel()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -331,6 +331,11 @@ func newConfig(buildConfig []byte, rewriteDockerRepositoryName bool) (*Config, e
 		}
 	}
 
+	buildType := Snapshot
+	if envBuildType, err := findEnv(env, "BUILD_TYPE"); err == nil {
+		buildType = BuildType(envBuildType)
+	}
+
 	builderSpec := BuilderSpec{}
 
 	if builderVersion, present := os.LookupEnv("APP_VERSION"); present {
@@ -406,6 +411,7 @@ func newConfig(buildConfig []byte, rewriteDockerRepositoryName bool) (*Config, e
 		SporingsContext:   sporingscontext,
 		Sporingstjeneste:  sporingstjeneste,
 		OwnerReferenceUid: string(build.UID),
+		BuildType:         buildType,
 	}
 	return c, nil
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -30,6 +30,13 @@ const (
 	Doozerleveransepakke Classifier = "Doozerleveransepakke"
 )
 
+type BuildType string
+
+const (
+	Snapshot BuildType = "Snapshot"
+	Release  BuildType = "Release"
+)
+
 type Config struct {
 	ApplicationType   ApplicationType
 	ApplicationSpec   ApplicationSpec
@@ -43,6 +50,7 @@ type Config struct {
 	SporingsContext   string
 	Sporingstjeneste  string
 	OwnerReferenceUid string
+	BuildType         BuildType
 }
 
 type NexusAccess struct {


### PR DESCRIPTION
Åpner opp for å bygge relase-versjoner med binary bygg. Dette for å stoppe opplastning av Leveransepakker, da de ikke blir brukt til noe etter Docker Image er ferdig bygd.
La til en liten guard på binary bygg. Med å måtte sende inn en miljøvariabel BUILD_TYPE=Release, det betyr at vi må oppdatere release-template med denne miljøvariablen før architect releases. Litt usikker på denne måten å gjøre det på, noen tanker?