### PR TITLE
Adjust timeout for trace data

### DIFF
--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -29,7 +29,7 @@ type Tracer struct {
 func (t *Tracer) AddImageMetadata(data interface{}) {
 	if t.enabled {
 		ctx := context.Background()
-		timeoutIn := time.Now().Add(30 * time.Millisecond)
+		timeoutIn := time.Now().Add(5 * time.Second)
 		ctx, cancelFunc := context.WithDeadline(ctx, timeoutIn)
 		defer cancelFunc()
 


### PR DESCRIPTION
Timeout was not previously used on 2-release branch (@welcor fixed it on master), but is used now as we merged with master. The timeout value, however, was always too short.